### PR TITLE
Add efuse check to run-avrdude

### DIFF
--- a/arduino/yun-scripts/files/usr/bin/run-avrdude
+++ b/arduino/yun-scripts/files/usr/bin/run-avrdude
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo 1 > /sys/class/gpio/gpio21/value
-echo "checking value of efuse"; avrdude  -q -q -c linuxgpio -C /etc/avrdude.conf -p m32u4 -U efuse:r:/tmp/efuse:d; read efuse</tmp/efuse; rm /tmp/efuse 
+avrdude  -q -q -c linuxgpio -C /etc/avrdude.conf -p m32u4 -U efuse:r:/tmp/efuse:d; read efuse</tmp/efuse; rm /tmp/efuse 
 if [ $efuse -eq 203 ] # 203 = 0xCB
 then 
     avrdude -c linuxgpio -C /etc/avrdude.conf -p m32u4 -U lfuse:w:0xFF:m -U hfuse:w:0xD8:m -U efuse:w:0xCB:m -Uflash:w:$1:i $2


### PR DESCRIPTION
If efuse on 32u4 is set to 0xcb, runs avrdude with that value. Otherwise runs avrdude with 0xfb as original
