### PR TITLE
Added fix for this_thread::sleep_for

### DIFF
--- a/devel/yun-gcc/Makefile
+++ b/devel/yun-gcc/Makefile
@@ -62,6 +62,7 @@ define Build/Configure
 		--disable-multilib \
 		--disable-nls \
 		--with-float=soft \
+		--enable-libstdcxx-time
 		--enable-languages=c,c++ 
 endef
 


### PR DESCRIPTION
When I tried to use <thread> with the sleep_for method I got errors that sleep_for is not a member of this_thread.  By following the advice at this post http://stackoverflow.com/questions/12523122/what-is-glibcxx-use-nanosleep-all-about I am going to see if I can rebuild GCC to fix this bug.